### PR TITLE
Feature/better readability Virtual Service and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,23 @@ functions:
               enabled: true
 ```
 
+You can you can optionally configure a virtual_service name, url, basepath and tags.
+```yaml
+custom:
+  kong:
+    admin_api_url: http://localhost:8001
+    virtual_service:
+      name: lambda-BFF-service
+      url: http://localhost:8001
+      base_path: /bff
+    tags:
+      - serverless-plugin-kong
+      - lambda-BFF-virtual-service
+    lambda:
+      config:
+        aws_key: ${env:AWS_ACCESS_KEY_ID, 'asdf'}
+        aws_secret: ${env:AWS_SECRET_ACCESS_KEY, 'asdf'}
+```
 ## Contributing
 
 Pull requests welcome! Please fork the repo and submit your PR.

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -34,6 +34,9 @@ custom:
       name: lambda-BFF-service
       url: http://localhost:8001
       base_path: /bff
+    tags:
+      - serverless-plugin-kong
+      - lambda-BFF-virtual-service
     lambda:
       config:
         aws_key: ${env:AWS_ACCESS_KEY_ID, 'asdf'}

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -7,7 +7,7 @@ service: example
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs18.x
 
 functions:
   hello:
@@ -30,6 +30,10 @@ functions:
 custom:
   kong:
     admin_api_url: http://localhost:8001
+    virtual_service:
+      name: lambda-BFF-service
+      url: http://localhost:8001
+      base_path: /bff
     lambda:
       config:
         aws_key: ${env:AWS_ACCESS_KEY_ID, 'asdf'}

--- a/index.js
+++ b/index.js
@@ -24,12 +24,17 @@ class ServerlessPlugin {
 
     const defaultConfig = (this.serverless.config.serverless.service.custom || {}).kong || {};
     const defaultLambdaConfig = (defaultConfig.lambda || {}).config || {};
+    const defaultVirtualService = defaultConfig.virtual_service || {};
+    const detaultBasePath = defaultVirtualService.base_path || '';
 
     this.kong = new Kong({ adminAPIURL: defaultConfig.admin_api_url || 'http://localhost:8001' });
 
-    // Create the dummy service for Lambda
-    const service = await this.kong.services.createOrUpdate('lambda-dummy-service', {
-      url: 'http://localhost:8001',
+    // Create a Virtual Service for Lambda Functions
+    const serviceName = defaultVirtualService.name || this.serverless.configurationInput.service
+    const serviceUrl = defaultVirtualService.url || 'http://localhost:8000'
+
+    const service = await this.kong.services.createOrUpdate(serviceName, {
+      url: serviceUrl,
     });
 
     // get the current routes in Kong


### PR DESCRIPTION
 - add Virtual service configuration instead fixed dummy service
 - add route name to better readability and troubleshooting
 - add possibility to add BasePath to configure routes
 - add possibility to add default tags to service, routes and plugins (its necessary to merge [this PR](https://github.com/troposhq/kong-admin-api-client/pull/1) on repo 
[kong-admin-api-client](https://github.com/troposhq/kong-admin-api-client) to add tags)
 - refactor to split some code in functions
 - refactor to execute deletes and update in parallel